### PR TITLE
[DS-B-9] Add validation

### DIFF
--- a/src/DirectoryService.Application/DependencyInjection.cs
+++ b/src/DirectoryService.Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using DirectoryService.Application.Locations.Create;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DirectoryService.Application;
@@ -7,8 +8,10 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        var assembly = typeof(DependencyInjection).Assembly;
+        services.AddValidatorsFromAssembly(assembly);
         services.AddScoped<CreateLocationHandler>();
-
+        
         return services;
     }    
 }

--- a/src/DirectoryService.Application/DirectoryService.Application.csproj
+++ b/src/DirectoryService.Application/DirectoryService.Application.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     </ItemGroup>

--- a/src/DirectoryService.Application/Extensions/ValidationExtensions.cs
+++ b/src/DirectoryService.Application/Extensions/ValidationExtensions.cs
@@ -1,0 +1,28 @@
+﻿using CSharpFunctionalExtensions;
+using FluentValidation;
+using FluentValidation.Results;
+using Shared.Errors;
+
+namespace DirectoryService.Application.Extensions;
+
+public static class ValidationExtensions
+{
+    public static IRuleBuilderOptionsConditions<T, TElement> CanMakeValueObject<T, TElement, TValueObject>
+    (this IRuleBuilder<T, TElement> ruleBuilder, Func<TElement, Result<TValueObject, Error>> factoryMethod)
+    {
+        return ruleBuilder.Custom((value, context) =>
+        {
+            Result<TValueObject, Error> result = factoryMethod(value);
+
+            if (!result.IsFailure)
+                return;
+            
+            context.AddFailure(result.Error.Serialize());
+        });
+    }
+
+    public static Errors ToAppErrors(this IEnumerable<ValidationFailure> failures)
+    {
+        return new Errors(failures.Select(failure => Error.Deserialize(failure.ErrorMessage)));
+    }
+}

--- a/src/DirectoryService.Application/Locations/Create/CreateLocationCommand.cs
+++ b/src/DirectoryService.Application/Locations/Create/CreateLocationCommand.cs
@@ -1,10 +1,9 @@
 ﻿using DirectoryService.Contracts.Dtos;
+using DirectoryService.Contracts.Locations.Create;
 
 namespace DirectoryService.Application.Locations.Create;
 
 public record CreateLocationCommand
 {
-    public required string Name { get; set; }
-    public required AddressDto Address { get; set; }
-    public required string Timezone { get; set; }
+    public CreateLocationRequest Request { get; set; }
 }

--- a/src/DirectoryService.Application/Locations/Create/CreateLocationValidator.cs
+++ b/src/DirectoryService.Application/Locations/Create/CreateLocationValidator.cs
@@ -1,0 +1,34 @@
+﻿using DirectoryService.Application.Extensions;
+using DirectoryService.Domain;
+using DirectoryService.Domain.ValueObjects;
+using FluentValidation;
+using Shared.Errors;
+
+namespace DirectoryService.Application.Locations.Create;
+
+public class CreateLocationValidator : AbstractValidator<CreateLocationCommand>
+{
+    public CreateLocationValidator()
+    {
+        RuleFor(command => command.Request.Name)
+            .CanMakeValueObject(LocationName.Create);
+
+        RuleFor(command => command.Request.Timezone)
+            .CanMakeValueObject(Timezone.Create);
+
+        RuleFor(command => command.Request.Address)
+            .NotEmpty()
+            .Custom((addressDto, context) =>
+            {
+                var result = Address.Create(
+                    addressDto.Country,
+                    addressDto.City,
+                    addressDto.Street,
+                    addressDto.Building,
+                    addressDto.RoomNumber);
+        
+                if (result.IsFailure)
+                    context.AddFailure(result.Error.Serialize());
+            });
+    }
+}

--- a/src/DirectoryService.Application/Repositories/ILocationRepository.cs
+++ b/src/DirectoryService.Application/Repositories/ILocationRepository.cs
@@ -1,8 +1,11 @@
 ﻿using DirectoryService.Domain.Entities;
+using DirectoryService.Domain.ValueObjects;
 
 namespace DirectoryService.Application.Repositories;
 
 public interface ILocationRepository
 {
     Task<Guid> CreateAsync(Location location, CancellationToken cancellationToken);
+    Task<bool> ExistsByNameAsync(LocationName locationName, CancellationToken cancellationToken);
+    Task<bool> ExistsByAddressAsync(Address address, CancellationToken cancellationToken);
 }

--- a/src/DirectoryService.Infrastructure/EfCore/AppDbContext.cs
+++ b/src/DirectoryService.Infrastructure/EfCore/AppDbContext.cs
@@ -7,6 +7,7 @@ namespace DirectoryService.Infrastructure.EfCore;
 public class AppDbContext : DbContext
 {
     public DbSet<Department> Departments { get; set; }
+    public DbSet<Location> Locations { get; set; }
 
     public AppDbContext(DbContextOptions<AppDbContext> options)
         : base(options)

--- a/src/DirectoryService.Infrastructure/Repositories/LocationRepository.cs
+++ b/src/DirectoryService.Infrastructure/Repositories/LocationRepository.cs
@@ -1,6 +1,8 @@
 ﻿using DirectoryService.Application.Repositories;
 using DirectoryService.Domain.Entities;
+using DirectoryService.Domain.ValueObjects;
 using DirectoryService.Infrastructure.EfCore;
+using Microsoft.EntityFrameworkCore;
 
 namespace DirectoryService.Infrastructure.Repositories;
 
@@ -15,9 +17,19 @@ public class LocationRepository : ILocationRepository
     
     public async Task<Guid> CreateAsync(Location location, CancellationToken cancellationToken)
     {
-        await _dbContext.AddAsync(location, cancellationToken);
+        await _dbContext.Locations.AddAsync(location, cancellationToken);
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         return location.Id;
+    }
+
+    public async Task<bool> ExistsByNameAsync(LocationName locationName, CancellationToken cancellationToken)
+    {
+        return await _dbContext.Locations.AnyAsync(l => l.LocationName == locationName, cancellationToken);
+    }
+
+    public async Task<bool> ExistsByAddressAsync(Address address, CancellationToken cancellationToken)
+    {
+        return await _dbContext.Locations.AnyAsync(l => l.Address == address, cancellationToken);
     }
 }

--- a/src/DirectoryService.Presentation/Controllers/LocationsController.cs
+++ b/src/DirectoryService.Presentation/Controllers/LocationsController.cs
@@ -16,9 +16,7 @@ public class LocationsController : ApplicationController
     {
         var command = new CreateLocationCommand()
         {
-            Name = request.Name,
-            Timezone = request.Timezone,
-            Address = request.Address
+            Request = request
         };
         
         var result = await handler.HandleAsync(command, cancellationToken);

--- a/src/Shared/Errors/AppErrors.cs
+++ b/src/Shared/Errors/AppErrors.cs
@@ -6,35 +6,42 @@ public static partial class AppErrors
     {
         public static Error CannotBeEmpty(string name)
         {
-            return Error.Validation("param.is.empty", $"Parameter '{name}' cannot be empty");
+            return Error.Validation(
+                "param.is.empty",
+                $"Parameter '{name}' cannot be empty",
+                $"{name}");
         }
 
         public static Error LengthNotInRange(string name, int min, int max)
         {
             return Error.Validation(
                 "param.bad.length",
-                $"Parameter '{name}' length must be between {min} and {max}");
+                $"Parameter '{name}' length must be between {min} and {max}",
+                $"{name}");
         }
 
         public static Error BadFormat(string name, string allowed)
         {
             return Error.Validation(
                 "param.bad.format",
-                $"Parameter '{name}' has invalid format. Allowed: '{allowed}'");
+                $"Parameter '{name}' has invalid format. Allowed: '{allowed}'",
+                $"{name}");
         }
 
         public static Error TooLong(string name, int max)
         {
             return Error.Validation(
                 "param.bad.length",
-                $"Parameter '{name}' is too long. Max: '{max}' symbols");
+                $"Parameter '{name}' is too long. Max: '{max}' symbols",
+                $"{name}");
         }
 
         public static Error MustBeGreaterOrEqualThan(string name, int min)
         {
             return Error.Validation(
                 "param.too.small",
-                $"Parameter '{name}' must be greater than or equal to '{min}'");
+                $"Parameter '{name}' must be greater than or equal to '{min}'",
+                $"{name}");
         }
     }
 
@@ -44,6 +51,12 @@ public static partial class AppErrors
         {
             return Error.Validation("record.not.found", $"Record with given id='{id}' was not found");
         }
+
+        public static Error AlreadyExists(string fieldName)
+        {
+            return Error.Conflict("record.already_exists", $"Record with given '{fieldName}' already exists");
+        }
+        
 
         public static Error SomethingWentWrong()
         {

--- a/src/Shared/Errors/Error.cs
+++ b/src/Shared/Errors/Error.cs
@@ -1,14 +1,14 @@
 ﻿using System.Text.Json.Serialization;
-
 namespace Shared.Errors;
 
 public record Error
 {
+    private const string Separator = "@#$"; 
     public string Code { get; }
     public string Message { get; }
     
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public ErrorType  Type { get; }
+    public ErrorType Type { get; }
     public string? InvalidField { get; }
     private Error(string code, string message, ErrorType type, string? invalidField = null)
     {
@@ -18,6 +18,25 @@ public record Error
         InvalidField = invalidField;
     }
 
+    public string Serialize()
+    {
+        return $"{Code}{Separator}{Message}{Separator}{Type}{Separator}{InvalidField}";
+    }
+
+    public static Error Deserialize(string json)
+    {
+        var args = json.Split(Separator);
+        
+        if (args.Length != 4)
+            throw new InvalidOperationException("Неверный формат сериализованных данных.");
+        
+        return new Error(
+            args[0],
+            args[1],
+            (ErrorType)Enum.Parse(typeof(ErrorType), args[2]),
+            string.IsNullOrWhiteSpace(args[3]) ?  null : args[3]);
+    }
+    
     public static Error Validation(string code, string message, string?  invalidField = null)
     {
         return new Error(code, message, ErrorType.Validation, invalidField);


### PR DESCRIPTION
Для Location сделал валидацию чисто на ValueObject , без дополнительной валидации инпутов, т.к. все передаваемые поля у меня VO. 

1. Вопрос такой, если НЕ КАЖДЫЙ инпут мы можем проверить с помощью VO, то будет ли правильно делать:
NotEmpty, HasMaxLength и другие правила - и для каждого правила прописывать WithMessage(AppErrors.Validation.CannotBeEmpty("name").Serialize())
WithMessage(AppErrors.Validation.CannotBeGreaterThan("roomNumber", 500)) 
Чтобы все ошибки валидации были в нашем стандартизированном виде
Норм подход?